### PR TITLE
Modified Parse() method so that it returns additional informations

### DIFF
--- a/include/brlcad/CommandString/CommandString.h
+++ b/include/brlcad/CommandString/CommandString.h
@@ -40,24 +40,19 @@ namespace BRLCAD {
         CommandString(Database& database);
         ~CommandString(void);
 
-        bool Parse(const std::vector<const char*>& arguments);
-
-        enum class ParseFlag {
-            Ok,        // Command execution was successful (no further informations)
-            Help,      // Invalid command, the Result string contains usage informations
-            More,      // Incomplete specification, the Result string will ask for more parameters
-            Quiet,     // Command won't set or modify the Result string
-            Unknown,   // Unknown command (arguments.front() not recognized)
-            Exit,      // Command is requesting a clean application shutdown
-            Override,  // Indicates settings have been overridden
-            Undefined
+        enum class State {
+            Success,
+            SuccessQuiet,     ///< the result string is not set
+            Incomplete,       ///< the result string asks for more data
+            SyntaxError,      ///< the result string contains usage information 
+            UnknownCommand,
+            OverrideSettings,
+            ExitRequested,
+            NoDatabase,
+            InternalError
         };
 
-        bool Parse(const std::vector<const char*>& arguments,
-                   ParseFlag                       flag);
-
-        bool Parse(const std::vector<const char*>&            arguments,
-                   const std::function<void(ParseFlag flag)>& callback);
+        State Parse(const std::vector<const char*>& arguments);
 
         const char* Results(void) const;
         size_t      NumberOfResults(void) const;

--- a/include/brlcad/CommandString/CommandString.h
+++ b/include/brlcad/CommandString/CommandString.h
@@ -42,6 +42,20 @@ namespace BRLCAD {
 
         bool Parse(const std::vector<const char*>& arguments);
 
+        enum class ParseFlag {
+            Ok,        // Command execution was successful (no further informations)
+            Help,      // Invalid command, the Result string contains usage informations
+            More,      // Incomplete specification, the Result string will ask for more parameters
+            Quiet,     // Command won't set or modify the Result string
+            Unknown,   // Unknown command (arguments.front() not recognized)
+            Exit,      // Command is requesting a clean application shutdown
+            Override,  // Indicates settings have been overridden
+            Undefined
+        };
+
+        bool Parse(const std::vector<const char*>& arguments,
+                   ParseFlag                       flag);
+
         const char* Results(void) const;
         size_t      NumberOfResults(void) const;
         const char* Result(size_t index) const;

--- a/include/brlcad/CommandString/CommandString.h
+++ b/include/brlcad/CommandString/CommandString.h
@@ -56,6 +56,9 @@ namespace BRLCAD {
         bool Parse(const std::vector<const char*>& arguments,
                    ParseFlag                       flag);
 
+        bool Parse(const std::vector<const char*>&            arguments,
+                   const std::function<void(ParseFlag flag)>& callback);
+
         const char* Results(void) const;
         size_t      NumberOfResults(void) const;
         const char* Result(size_t index) const;

--- a/src/CommandString/CommandString.cpp
+++ b/src/CommandString/CommandString.cpp
@@ -85,40 +85,39 @@ CommandString::State CommandString::Parse
 (
     const std::vector<const char*>& arguments
 ) {
-    int ret = BRLCAD_ERROR;
+    CommandString::State ret  = CommandString::State::NoDatabase;
+    int                  gret = BRLCAD_ERROR;
 
     if (m_ged != nullptr) {
         if (!BU_SETJUMP)
-            ret = ged_exec(m_ged, arguments.size(), const_cast<const char**>(arguments.data()));
+            gret = ged_exec(m_ged, arguments.size(), const_cast<const char**>(arguments.data()));
         else {
             BU_UNSETJUMP;
 
-            return State::InternalError;
+            ret = State::InternalError;
         }
 
         BU_UNSETJUMP;
     }
-    else
-        return State::NoDatabase;
 
-    if (ret == BRLCAD_OK)
-        return State::Success;
+    if (gret == BRLCAD_OK)
+        ret = State::Success;
     else {
-        if (ret & GED_QUIET)
-            return State::SuccessQuiet;
-        else if (ret & GED_MORE)
-            return State::Incomplete;
-        else if (ret & GED_HELP)
-            return State::SyntaxError;
-        else if (ret & GED_UNKNOWN)
-            return State::UnknownCommand;
-        else if (ret & GED_OVERRIDE)
-            return State::OverrideSettings;
-        else if (ret & GED_EXIT)
-            return State::ExitRequested;
+        if (gret & GED_QUIET)
+            ret = State::SuccessQuiet;
+        else if (gret & GED_MORE)
+            ret = State::Incomplete;
+        else if (gret & GED_HELP)
+            ret = State::SyntaxError;
+        else if (gret & GED_UNKNOWN)
+            ret = State::UnknownCommand;
+        else if (gret & GED_OVERRIDE)
+            ret = State::OverrideSettings;
+        else if (gret & GED_EXIT)
+            ret = State::ExitRequested;
     }
 
-    return State::InternalError;
+    return ret;
 }
 
 

--- a/src/CommandString/CommandString.cpp
+++ b/src/CommandString/CommandString.cpp
@@ -98,6 +98,49 @@ bool CommandString::Parse
 }
 
 
+bool CommandString::Parse
+(
+    const std::vector<const char*>& arguments,
+    ParseFlag                       flag
+) {
+    int ret = BRLCAD_ERROR;
+    flag = ParseFlag::Undefined;
+
+    if (m_ged != nullptr) {
+        if (!BU_SETJUMP)
+            ret = ged_exec(m_ged, arguments.size(), const_cast<const char**>(arguments.data()));
+        else {
+            BU_UNSETJUMP;
+
+            return 1;
+        }
+
+        BU_UNSETJUMP;
+    }
+    else
+        return 1;
+
+    if (ret == BRLCAD_OK)
+        flag = ParseFlag::Ok;
+    else {
+        if (ret & GED_HELP)
+            flag = ParseFlag::Help;
+        else if (ret & GED_MORE)
+            flag = ParseFlag::More;
+        else if (ret & GED_QUIET)
+            flag = ParseFlag::Quiet;
+        else if (ret & GED_UNKNOWN)
+            flag = ParseFlag::Unknown;
+        else if (ret & GED_EXIT)
+            flag = ParseFlag::Exit;
+        else if (ret & GED_OVERRIDE)
+            flag = ParseFlag::Override;
+    }
+
+    return 0;
+}
+
+
 const char* CommandString::Results(void) const {
     return bu_vls_cstr(m_ged->ged_result_str);
 }


### PR DESCRIPTION
The goal of this PR is to have additional informations if the Parse method returns an error.

Particularly, this PR was done to support the handling of multi inputs commands for the new arbalest's console.