### PR TITLE
Fix for `Parse` causing errors for commands that return `GED_MORE` or `GED_HELP`

### DIFF
--- a/src/CommandString/CommandString.cpp
+++ b/src/CommandString/CommandString.cpp
@@ -97,17 +97,17 @@ CommandString::State CommandString::Parse
                 ret = State::Success;
             else if (gedResult == GED_EXIT)
                 ret = State::ExitRequested;
+            else if  (gedResult & GED_MORE)
+                ret = State::Incomplete;
+            else if (gedResult & GED_HELP)
+                ret = State::SyntaxError;
             else {
                 assert((gedResult & BRLCAD_ERROR) != 0);
 
                 ret = State::Error;
 
                 // check, if the error type is specified
-                if (gedResult & GED_MORE)
-                    ret = State::Incomplete;
-                else if (gedResult & GED_HELP)
-                    ret = State::SyntaxError;
-                else if (gedResult & GED_UNKNOWN)
+                if (gedResult & GED_UNKNOWN)
                     ret = State::UnknownCommand;
                 else
                     assert(gedResult == BRLCAD_ERROR);


### PR DESCRIPTION
Looking at libged, it seems to me that `GED_MORE` and `GED_HELP` are returned without being combined with `BRLCAD_ERROR`.

More precisely, I think that `GED_HELP` is returned **only** when a command is called without any more arguments (e.g.: "make", "comb"). In these situations, the command execution is treated as successful, and the command returns `BRLCAD_OK | GED_HELP`, and it prints out the command usage.

If, instead, there is a problem in the command syntax (e.g.: "make name not-an-object-type"), then the command returns `BRLCAD_ERROR` **without** being combined with `GED_HELP`, **even though** the command usage is still printed out.

The same goes for `GED_MORE`, which is returned only when a command is correct but requires more inputs (e.g.: "mater obj"). In these situations, the command execution is treated as successful, and the command returns `BRLCAD_OK | GED_MORE`, and it prints out the required inputs.