### PR TITLE
Changed callbacks argument from Object to const char* (objectName)

### DIFF
--- a/include/brlcad/Database/ConstDatabase.h
+++ b/include/brlcad/Database/ConstDatabase.h
@@ -181,8 +181,8 @@ namespace BRLCAD {
         };
 
         /// signal handler (to be implemented by the caller)
-        typedef std::function<void(const Object& object,
-                                   ChangeType    changeType)> ChangeSignalHandler;
+        typedef std::function<void(const char* objectName,
+                                   ChangeType  changeType)> ChangeSignalHandler;
 
         void                 RegisterChangeSignalHandler(ChangeSignalHandler& changeSignalHandler);
         void                 DeRegisterChangeSignalHandler(ChangeSignalHandler& changeSignalHandler);

--- a/src/Database/ConstDatabase.cpp
+++ b/src/Database/ConstDatabase.cpp
@@ -881,7 +881,7 @@ void ConstDatabase::SignalChange
 ) const {
     if ((m_rtip != nullptr) && (m_rtip->rti_dbip == dbip)) {
         ChangeType  changeType;
-        const char* objectName = 0;
+        const char* objectName = nullptr;
 
         switch (mode) {
         case 0:

--- a/src/Database/ConstDatabase.cpp
+++ b/src/Database/ConstDatabase.cpp
@@ -900,9 +900,9 @@ void ConstDatabase::SignalChange
             changeType = ChangeType::Unknown;
         }
 
-        assert(pDir != 0);
+        assert(pDir != nullptr);
 
-        if (pDir != 0)
+        if (pDir != nullptr)
             objectName = pDir->d_namep;
 
         for (size_t i = 0; i < m_changeSignalHandlers.size(); ++i)

--- a/src/Database/ConstDatabase.cpp
+++ b/src/Database/ConstDatabase.cpp
@@ -880,7 +880,8 @@ void ConstDatabase::SignalChange
     int        mode
 ) const {
     if ((m_rtip != nullptr) && (m_rtip->rti_dbip == dbip)) {
-        ChangeType changeType;
+        ChangeType  changeType;
+        const char* objectName = 0;
 
         switch (mode) {
         case 0:
@@ -899,12 +900,12 @@ void ConstDatabase::SignalChange
             changeType = ChangeType::Unknown;
         }
 
-        if (!BU_SETJUMP)
-            GetInternal(pDir, [&] (const Object& object) {
-                for (size_t i = 0; i < m_changeSignalHandlers.size(); ++i)
-                    (*m_changeSignalHandlers[i])(object, changeType);
-            });
+        assert(pDir != 0);
 
-        BU_UNSETJUMP;
+        if (pDir != 0)
+            objectName = pDir->d_namep;
+
+        for (size_t i = 0; i < m_changeSignalHandlers.size(); ++i)
+            (*m_changeSignalHandlers[i])(objectName, changeType);
     }
 }


### PR DESCRIPTION
The goal of this PR is to avoid a bunch of issues related to using `rt_db_get_internal` inside a callback function.