### PR TITLE
Added Arb8 C API wrapper

### DIFF
--- a/include/brlcad/C/arb8.h
+++ b/include/brlcad/C/arb8.h
@@ -26,35 +26,33 @@
 #ifndef BRLCAD_C_ARB8_INCLUDED
 #define BRLCAD_C_ARB8_INCLUDED
 
-#include <brlcad/C/handle.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-typedef BrlHandle BrlArb8;
+typedef void* BrlArb8;
 
 
-BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8FromBoxCoords(
-	double p1x, double p1y, double p1z,
-	double p2x, double p2y, double p2z);
+BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8From2Points(
+	double point1X, double point1Y, double point1Z,
+    double point2X, double point2Y, double point2Z);
 
 BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8From4Points(
-	double p1x, double p1y, double p1z,
-	double p2x, double p2y, double p2z,
-	double p3x, double p3y, double p3z,
-	double p4x, double p4y, double p4z);
+	double point1X, double point1Y, double point1Z,
+    double point2X, double point2Y, double point2Z,
+    double point3X, double point3Y, double point3Z,
+    double point4X, double point4Y, double point4Z);
 
 BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8From8Points(
-	double p1x, double p1y, double p1z,
-	double p2x, double p2y, double p2z,
-	double p3x, double p3y, double p3z,
-	double p4x, double p4y, double p4z,
-	double p5x, double p5y, double p5z,
-	double p6x, double p6y, double p6z,
-	double p7x, double p7y, double p7z,
-	double p8x, double p8y, double p8z);
+	double point1X, double point1Y, double point1Z,
+    double point2X, double point2Y, double point2Z,
+    double point3X, double point3Y, double point3Z,
+    double point4X, double point4Y, double point4Z,
+    double point5X, double point5Y, double point5Z,
+    double point6X, double point6Y, double point6Z,
+    double point7X, double point7Y, double point7Z,
+    double point8X, double point8Y, double point8Z);
 
     
 #ifdef __cplusplus

--- a/include/brlcad/C/arb8.h
+++ b/include/brlcad/C/arb8.h
@@ -32,12 +32,31 @@
 extern "C" {
 #endif
 
-// Creates an Arb8 by passing 2 points (diagonals for a box)
-BRLCAD_MOOSE_EXPORT BrlHandle BrlNewArb8FromBox(const double* p1, const double* p2);
 
-// Creates an Arb8 by passing all 8 points (24 numbers total)
-BRLCAD_MOOSE_EXPORT BrlHandle BrlNewArb8FromPoints(const double* flatPoints24);
+typedef BrlHandle BrlArb8;
 
+
+BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8FromBoxCoords(
+	double p1x, double p1y, double p1z,
+	double p2x, double p2y, double p2z);
+
+BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8From4Points(
+	double p1x, double p1y, double p1z,
+	double p2x, double p2y, double p2z,
+	double p3x, double p3y, double p3z,
+	double p4x, double p4y, double p4z);
+
+BRLCAD_MOOSE_EXPORT BrlArb8 BrlNewArb8From8Points(
+	double p1x, double p1y, double p1z,
+	double p2x, double p2y, double p2z,
+	double p3x, double p3y, double p3z,
+	double p4x, double p4y, double p4z,
+	double p5x, double p5y, double p5z,
+	double p6x, double p6y, double p6z,
+	double p7x, double p7y, double p7z,
+	double p8x, double p8y, double p8z);
+
+    
 #ifdef __cplusplus
 }
 #endif

--- a/include/brlcad/C/arb8.h
+++ b/include/brlcad/C/arb8.h
@@ -20,7 +20,7 @@
 /** @file arb8.h
  *
  *  BRL-CAD core simplified C interface:
- *      declares a handle and functions for a read-only database
+ *      declares a handle and functions for Arb8 geometry construction
  */
 
 #ifndef BRLCAD_C_ARB8_INCLUDED

--- a/include/brlcad/C/arb8.h
+++ b/include/brlcad/C/arb8.h
@@ -1,0 +1,45 @@
+/*                      A R B 8 . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2026 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ */
+/** @file arb8.h
+ *
+ *  BRL-CAD core simplified C interface:
+ *      declares a handle and functions for a read-only database
+ */
+
+#ifndef BRLCAD_C_ARB8_INCLUDED
+#define BRLCAD_C_ARB8_INCLUDED
+
+#include <brlcad/C/handle.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Creates an Arb8 by passing 2 points (diagonals for a box)
+BRLCAD_MOOSE_EXPORT BrlHandle BrlNewArb8FromBox(const double* p1, const double* p2);
+
+// Creates an Arb8 by passing all 8 points (24 numbers total)
+BRLCAD_MOOSE_EXPORT BrlHandle BrlNewArb8FromPoints(const double* flatPoints24);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BRLCAD_C_ARB8_INCLUDED

--- a/src/C/CMakeLists.txt
+++ b/src/C/CMakeLists.txt
@@ -24,22 +24,22 @@
 
 
 SET(CSources
+    C/arb8.cpp
     C/casts.cpp
     C/constDatabase.cpp
     C/fileDatabase.cpp
     C/globals.cpp
     C/handle.cpp
     C/memoryDatabase.cpp
-    C/arb8.cpp
 )
 
 SET(CHeaders
+    ${MOOSE_SOURCE_DIR}/include/brlcad/C/arb8.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/constDatabase.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/fileDatabase.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/globals.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/handle.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/memoryDatabase.h
-    ${MOOSE_SOURCE_DIR}/include/brlcad/C/arb8.h
 )
 
 INSTALL(FILES ${CHeaders} DESTINATION include/brlcad/C)

--- a/src/C/CMakeLists.txt
+++ b/src/C/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(CSources
     C/globals.cpp
     C/handle.cpp
     C/memoryDatabase.cpp
+    C/arb8.cpp
 )
 
 SET(CHeaders
@@ -38,6 +39,7 @@ SET(CHeaders
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/globals.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/handle.h
     ${MOOSE_SOURCE_DIR}/include/brlcad/C/memoryDatabase.h
+    ${MOOSE_SOURCE_DIR}/include/brlcad/C/arb8.h
 )
 
 INSTALL(FILES ${CHeaders} DESTINATION include/brlcad/C)

--- a/src/C/arb8.cpp
+++ b/src/C/arb8.cpp
@@ -1,0 +1,66 @@
+/*                      A R B 8 . C P P
+ * BRL-CAD
+ *
+ * Copyright (c) 2026 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ */
+/** @file arb8.cpp
+ *
+ *  BRL-CAD core simplified C interface:
+ *      implements a handle and functions for a read-only database
+ */
+
+#include <brlcad/C/arb8.h>
+
+#include <brlcad/Database/Arb8.h>
+
+#include <brlcad/vector.h>
+
+
+using namespace BRLCAD;
+
+
+BrlHandle BrlNewArb8FromBox
+(
+    const double* p1, const double* p2
+) {
+    if (!p1 || !p2) return nullptr;
+    
+    Vector3D vec1(p1[0], p1[1], p1[2]);
+    Vector3D vec2(p2[0], p2[1], p2[2]);
+        BrlHandle arb_handle = nullptr;
+        arb_handle = static_cast<BrlHandle>(new Arb8(vec1, vec2));
+        return arb_handle;
+}
+
+BrlHandle BrlNewArb8FromPoints
+(
+    const double* flatPoints24
+) {
+    if (!flatPoints24) return nullptr;
+    
+    // Unpack the 24 flat doubles into 8 Vector3D objects
+    Vector3D pts[8];
+    int idx = 0;
+    for(int i = 0; i < 8; ++i) {
+        pts[i] = Vector3D(flatPoints24[idx], flatPoints24[idx+1], flatPoints24[idx+2]);
+        idx += 3;
+    }
+        BrlHandle arb_handle = nullptr;
+        arb_handle = static_cast<BrlHandle>(new Arb8(pts[0], pts[1], pts[2], pts[3],
+                                                   pts[4], pts[5], pts[6], pts[7]));
+        return arb_handle;
+}

--- a/src/C/arb8.cpp
+++ b/src/C/arb8.cpp
@@ -34,34 +34,56 @@
 using namespace BRLCAD;
 
 
-BrlHandle BrlNewArb8FromBox
+//box coordinates as separate doubles
+BrlArb8 BrlNewArb8FromBoxCoords
 (
-    const double* p1, const double* p2
+    double p1x, double p1y, double p1z,
+    double p2x, double p2y, double p2z
 ) {
-    if (!p1 || !p2) return nullptr;
-    
-    Vector3D vec1(p1[0], p1[1], p1[2]);
-    Vector3D vec2(p2[0], p2[1], p2[2]);
-        BrlHandle arb_handle = nullptr;
-        arb_handle = static_cast<BrlHandle>(new Arb8(vec1, vec2));
-        return arb_handle;
+    Vector3D v1(p1x, p1y, p1z);
+    Vector3D v2(p2x, p2y, p2z);
+    BrlArb8 arb_handle = nullptr;
+    arb_handle = static_cast<BrlArb8>(new Arb8(v1, v2));
+    return arb_handle;
 }
 
-BrlHandle BrlNewArb8FromPoints
+//four points (12 doubles)
+BrlArb8 BrlNewArb8From4Points
 (
-    const double* flatPoints24
+    double p1x, double p1y, double p1z,
+    double p2x, double p2y, double p2z,
+    double p3x, double p3y, double p3z,
+    double p4x, double p4y, double p4z
 ) {
-    if (!flatPoints24) return nullptr;
-    
-    // Unpack the 24 flat doubles into 8 Vector3D objects
-    Vector3D pts[8];
-    int idx = 0;
-    for(int i = 0; i < 8; ++i) {
-        pts[i] = Vector3D(flatPoints24[idx], flatPoints24[idx+1], flatPoints24[idx+2]);
-        idx += 3;
-    }
-        BrlHandle arb_handle = nullptr;
-        arb_handle = static_cast<BrlHandle>(new Arb8(pts[0], pts[1], pts[2], pts[3],
-                                                   pts[4], pts[5], pts[6], pts[7]));
-        return arb_handle;
+    Vector3D p1(p1x, p1y, p1z);
+    Vector3D p2(p2x, p2y, p2z);
+    Vector3D p3(p3x, p3y, p3z);
+    Vector3D p4(p4x, p4y, p4z);
+    BrlArb8 arb_handle = nullptr;
+    arb_handle = static_cast<BrlArb8>(new Arb8(p1, p2, p3, p4));
+    return arb_handle;
+}
+
+//eight points (24 doubles)
+BrlArb8 BrlNewArb8From8Points
+(
+    double p1x, double p1y, double p1z,
+    double p2x, double p2y, double p2z,
+    double p3x, double p3y, double p3z,
+    double p4x, double p4y, double p4z,
+    double p5x, double p5y, double p5z,
+    double p6x, double p6y, double p6z,
+    double p7x, double p7y, double p7z,
+    double p8x, double p8y, double p8z
+) {
+    Vector3D pts[8] = {
+        Vector3D(p1x,p1y,p1z), Vector3D(p2x,p2y,p2z),
+        Vector3D(p3x,p3y,p3z), Vector3D(p4x,p4y,p4z),
+        Vector3D(p5x,p5y,p5z), Vector3D(p6x,p6y,p6z),
+        Vector3D(p7x,p7y,p7z), Vector3D(p8x,p8y,p8z)
+    };
+    BrlArb8 arb_handle = nullptr;
+    arb_handle = static_cast<BrlArb8>(new Arb8(pts[0], pts[1], pts[2], pts[3],
+                                               pts[4], pts[5], pts[6], pts[7]));
+    return arb_handle;
 }

--- a/src/C/arb8.cpp
+++ b/src/C/arb8.cpp
@@ -21,69 +21,64 @@
  *
  *  BRL-CAD core simplified C interface:
  *      implements wrappers for constructing Arb8 geometry objects
- *      from a box diagonal or from 8 explicit points
  */
 
 #include <brlcad/C/arb8.h>
 
 #include <brlcad/Database/Arb8.h>
 
-#include <brlcad/vector.h>
-
-
 using namespace BRLCAD;
 
 
-//box coordinates as separate doubles
-BrlArb8 BrlNewArb8FromBoxCoords
+// two points (6 doubles)
+BrlArb8 BrlNewArb8From2Points
 (
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z
+    double point1X, double point1Y, double point1Z,
+    double point2X, double point2Y, double point2Z
 ) {
-    Vector3D v1(p1x, p1y, p1z);
-    Vector3D v2(p2x, p2y, p2z);
-    BrlArb8 arb_handle = nullptr;
-    arb_handle = static_cast<BrlArb8>(new Arb8(v1, v2));
-    return arb_handle;
+    Vector3D point1(point1X, point1Y, point1Z);
+    Vector3D point2(point2X, point2Y, point2Z);
+
+    return new Arb8(point1, point2);
 }
 
-//four points (12 doubles)
+// four points (12 doubles)
 BrlArb8 BrlNewArb8From4Points
 (
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z,
-    double p3x, double p3y, double p3z,
-    double p4x, double p4y, double p4z
+    double point1X, double point1Y, double point1Z,
+    double point2X, double point2Y, double point2Z,
+    double point3X, double point3Y, double point3Z,
+    double point4X, double point4Y, double point4Z
 ) {
-    Vector3D p1(p1x, p1y, p1z);
-    Vector3D p2(p2x, p2y, p2z);
-    Vector3D p3(p3x, p3y, p3z);
-    Vector3D p4(p4x, p4y, p4z);
-    BrlArb8 arb_handle = nullptr;
-    arb_handle = static_cast<BrlArb8>(new Arb8(p1, p2, p3, p4));
-    return arb_handle;
+    Vector3D point1(point1X, point1Y, point1Z);
+    Vector3D point2(point2X, point2Y, point2Z);
+    Vector3D point3(point3X, point3Y, point3Z);
+    Vector3D point4(point4X, point4Y, point4Z);
+    
+    return new Arb8(point1, point2, point3, point4);
 }
 
-//eight points (24 doubles)
+// eight points (24 doubles)
 BrlArb8 BrlNewArb8From8Points
 (
-    double p1x, double p1y, double p1z,
-    double p2x, double p2y, double p2z,
-    double p3x, double p3y, double p3z,
-    double p4x, double p4y, double p4z,
-    double p5x, double p5y, double p5z,
-    double p6x, double p6y, double p6z,
-    double p7x, double p7y, double p7z,
-    double p8x, double p8y, double p8z
+    double point1X, double point1Y, double point1Z,
+    double point2X, double point2Y, double point2Z,
+    double point3X, double point3Y, double point3Z,
+    double point4X, double point4Y, double point4Z,
+    double point5X, double point5Y, double point5Z,
+    double point6X, double point6Y, double point6Z,
+    double point7X, double point7Y, double point7Z,
+    double point8X, double point8Y, double point8Z
 ) {
-    Vector3D pts[8] = {
-        Vector3D(p1x,p1y,p1z), Vector3D(p2x,p2y,p2z),
-        Vector3D(p3x,p3y,p3z), Vector3D(p4x,p4y,p4z),
-        Vector3D(p5x,p5y,p5z), Vector3D(p6x,p6y,p6z),
-        Vector3D(p7x,p7y,p7z), Vector3D(p8x,p8y,p8z)
-    };
-    BrlArb8 arb_handle = nullptr;
-    arb_handle = static_cast<BrlArb8>(new Arb8(pts[0], pts[1], pts[2], pts[3],
-                                               pts[4], pts[5], pts[6], pts[7]));
-    return arb_handle;
+    Vector3D point1(point1X, point1Y, point1Z);
+    Vector3D point2(point2X, point2Y, point2Z);
+    Vector3D point3(point3X, point3Y, point3Z);
+    Vector3D point4(point4X, point4Y, point4Z);
+    Vector3D point5(point5X, point5Y, point5Z);
+    Vector3D point6(point6X, point6Y, point6Z);
+    Vector3D point7(point7X, point7Y, point7Z);
+    Vector3D point8(point8X, point8Y, point8Z);
+
+    return new Arb8(point1, point2, point3, point4,
+                    point5, point6, point7, point8);
 }

--- a/src/C/arb8.cpp
+++ b/src/C/arb8.cpp
@@ -20,7 +20,8 @@
 /** @file arb8.cpp
  *
  *  BRL-CAD core simplified C interface:
- *      implements a handle and functions for a read-only database
+ *      implements wrappers for constructing Arb8 geometry objects
+ *      from a box diagonal or from 8 explicit points
  */
 
 #include <brlcad/C/arb8.h>


### PR DESCRIPTION
I am keeping the arb8.cpp and arb8.h seperate here because it fits in none of the current made files. I tested this with a small python code and I tested it with a small python script to ensure it works after building it. 
<img width="705" height="830" alt="image" src="https://github.com/user-attachments/assets/c8e8041f-540d-4981-898b-f997ba5dddd4" />
<img width="729" height="842" alt="image" src="https://github.com/user-attachments/assets/65316cff-2f71-4e12-85dc-c9f235a0e5af" />


<img width="847" height="265" alt="image" src="https://github.com/user-attachments/assets/5a69bf47-6c40-4864-86fb-0dc8cf095c6a" />
